### PR TITLE
CoreGraphics Initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Swift2D is distributed using the [Swift Package Manager](https://swift.org/packa
 let package = Package(
     ...
     dependencies: [
-        .package(url: "https://github.com/richardpiazza/Swift2D.git", from: "1.0.0")
+        .package(url: "https://github.com/richardpiazza/Swift2D.git", from: "1.1.0")
     ],
     ...
 )

--- a/Sources/Swift2D/Point+CoreGraphics.swift
+++ b/Sources/Swift2D/Point+CoreGraphics.swift
@@ -5,16 +5,24 @@ import Foundation
 #endif
 
 public extension Point {
+    /// Initialize a `Point` using the provided `CGPoint` values.
+    init(_ point: CGPoint) {
+        self.init(x: Float(point.x), y: Float(point.y))
+    }
+    
+    @available(*, deprecated, renamed: "CGPoint(_:)", message: "Use CGPoint initializer directly")
     var cgPoint: CGPoint {
         return CGPoint(self)
     }
 }
 
 public extension CGPoint {
+    /// Initialize a `CPPoint` using the provided `Point` values.
     init(_ point: Point) {
         self.init(x: CGFloat(point.x), y: CGFloat(point.y))
     }
     
+    @available(*, deprecated, renamed: "Point(_:)", message: "Use Point initializer directly")
     var point: Point {
         return Point(x: Float(x), y: Float(y))
     }

--- a/Sources/Swift2D/Rect+CoreGraphics.swift
+++ b/Sources/Swift2D/Rect+CoreGraphics.swift
@@ -5,16 +5,34 @@ import Foundation
 #endif
 
 public extension Rect {
+    /// Initialize a `Rect` using the provided `CGRect` values.
+    init(_ rect: CGRect) {
+        self.init(
+            x: Float(rect.origin.x),
+            y: Float(rect.origin.y),
+            width: Float(rect.width),
+            height: Float(rect.height)
+        )
+    }
+    
+    @available(*, deprecated, renamed: "CGRect(_:)", message: "Use CGRect initializer directly")
     var cgRect: CGRect {
         return CGRect(self)
     }
 }
 
 public extension CGRect {
+    /// Initialize a `CGRect` using the provided `Rect` values.
     init(_ rect: Rect) {
-        self.init(origin: rect.origin.cgPoint, size: rect.size.cgSize)
+        self.init(
+            x: CGFloat(rect.x),
+            y: CGFloat(rect.y),
+            width: CGFloat(rect.width),
+            height: CGFloat(rect.height)
+        )
     }
     
+    @available(*, deprecated, renamed: "Rect(_:)", message: "Use Rect initializer directly")
     var rect: Rect {
         return Rect(origin: origin.point, size: size.size)
     }

--- a/Sources/Swift2D/Size+CoreGraphics.swift
+++ b/Sources/Swift2D/Size+CoreGraphics.swift
@@ -5,16 +5,24 @@ import Foundation
 #endif
 
 public extension Size {
+    /// Initialize a `Size` using the provided `CGSize` values.
+    init(_ size: CGSize) {
+        self.init(width: Float(size.width), height: Float(size.height))
+    }
+    
+    @available(*, deprecated, renamed: "CGSize(_:)", message: "Use CGSize initializer directly")
     var cgSize: CGSize {
         return CGSize(self)
     }
 }
 
 public extension CGSize {
+    /// Initialize a `CGSize` using the provided `Size` values.
     init(_ size: Size) {
         self.init(width: CGFloat(size.width), height: CGFloat(size.height))
     }
     
+    @available(*, deprecated, renamed: "Size(_:)", message: "Use Size initializer directly")
     var size: Size {
         return Size(width: Float(width), height: Float(height))
     }

--- a/Tests/Swift2DTests/PointTests.swift
+++ b/Tests/Swift2DTests/PointTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import Swift2D
 #if canImport(CoreGraphics)
 import CoreGraphics
+#else
+import Foundation
 #endif
 
 final class PointTests: XCTestCase {
@@ -111,10 +113,10 @@ final class PointTests: XCTestCase {
     
     func testCoreGraphics() throws {
         let point = Point(x: 45, y: 60)
-        var cgPoint = point.cgPoint
+        var cgPoint = CGPoint(point)
         XCTAssertEqual(cgPoint.x, 45.0)
         XCTAssertEqual(cgPoint.y, 60.0)
-        XCTAssertEqual(cgPoint.point, .init(x: 45.0, y: 60.0))
+        XCTAssertEqual(Point(cgPoint), .init(x: 45.0, y: 60.0))
         cgPoint = CGPoint(Point(x: 24.7, y: 31.5))
         XCTAssertEqual(cgPoint.x, 24.7, accuracy: 0.0001)
         XCTAssertEqual(cgPoint.y, 31.5)

--- a/Tests/Swift2DTests/RectTests.swift
+++ b/Tests/Swift2DTests/RectTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import Swift2D
 #if canImport(CoreGraphics)
 import CoreGraphics
+#else
+import Foundation
 #endif
 
 final class RectTests: XCTestCase {
@@ -218,13 +220,13 @@ final class RectTests: XCTestCase {
     }
     
     func testCoreGraphics() throws {
-        var cgRect = Rect(x: 1.2, y: 3.4, width: 5.6, height: 7.8).cgRect
+        var cgRect = CGRect(Rect(x: 1.2, y: 3.4, width: 5.6, height: 7.8))
         XCTAssertEqual(cgRect.origin.x, 1.2, accuracy: 0.00001)
         XCTAssertEqual(cgRect.origin.y, 3.4, accuracy: 0.00001)
         XCTAssertEqual(cgRect.width, 5.6, accuracy: 0.00001)
         XCTAssertEqual(cgRect.height, 7.8, accuracy: 0.00001)
         cgRect = CGRect(.init(origin: Point(x: 12, y: 21), size: Size(width: 34, height: 43)))
-        let rect = cgRect.rect
+        let rect = Rect(cgRect)
         XCTAssertEqual(rect.x, 12.0, accuracy: 0.00001)
         XCTAssertEqual(rect.y, 21.0, accuracy: 0.00001)
         XCTAssertEqual(rect.width, 34.0, accuracy: 0.00001)

--- a/Tests/Swift2DTests/SizeTests.swift
+++ b/Tests/Swift2DTests/SizeTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import Swift2D
 #if canImport(CoreGraphics)
 import CoreGraphics
+#else
+import Foundation
 #endif
 
 final class SizeTests: XCTestCase {
@@ -113,10 +115,10 @@ final class SizeTests: XCTestCase {
     
     func testCoreGraphics() throws {
         let size = Size(width: 45, height: 60)
-        var cgSize = size.cgSize
+        var cgSize = CGSize(size)
         XCTAssertEqual(cgSize.width, 45.0)
         XCTAssertEqual(cgSize.height, 60.0)
-        XCTAssertEqual(cgSize.size, .init(width: 45.0, height: 60.0))
+        XCTAssertEqual(Size(cgSize), .init(width: 45.0, height: 60.0))
         cgSize = CGSize(Size(width: 24.7, height: 31.5))
         XCTAssertEqual(cgSize.width, 24.7, accuracy: 0.0001)
         XCTAssertEqual(cgSize.height, 31.5)


### PR DESCRIPTION
Added convenience initializers to `Rect`, `Size`, and `Point` that take CoreGraphics counterparts as parameters.