### PR TITLE
Double Raw Values

### DIFF
--- a/Sources/Swift2D/Point+Computed.swift
+++ b/Sources/Swift2D/Point+Computed.swift
@@ -1,9 +1,9 @@
 // MARK: - Static References
 public extension Point {
     static let zero: Point = Point(x: 0, y: 0)
-    static let nan: Point = Point(x: Float.nan, y: Float.nan)
-    internal static let infinite: Point = Point(x: -Float.greatestFiniteMagnitude / 2, y: -Float.greatestFiniteMagnitude / 2)
-    internal static let null: Point = Point(x: Float.infinity, y: Float.infinity)
+    static let nan: Point = Point(x: Double.nan, y: Double.nan)
+    internal static let infinite: Point = Point(x: -Double.greatestFiniteMagnitude / 2, y: -Double.greatestFiniteMagnitude / 2)
+    internal static let null: Point = Point(x: Double.infinity, y: Double.infinity)
     
     var isZero: Bool {
         return self == .zero

--- a/Sources/Swift2D/Point+CoreGraphics.swift
+++ b/Sources/Swift2D/Point+CoreGraphics.swift
@@ -7,12 +7,7 @@ import Foundation
 public extension Point {
     /// Initialize a `Point` using the provided `CGPoint` values.
     init(_ point: CGPoint) {
-        self.init(x: Float(point.x), y: Float(point.y))
-    }
-    
-    @available(*, deprecated, renamed: "CGPoint(_:)", message: "Use CGPoint initializer directly")
-    var cgPoint: CGPoint {
-        return CGPoint(self)
+        self.init(x: Double(point.x), y: Double(point.y))
     }
 }
 
@@ -20,10 +15,5 @@ public extension CGPoint {
     /// Initialize a `CPPoint` using the provided `Point` values.
     init(_ point: Point) {
         self.init(x: CGFloat(point.x), y: CGFloat(point.y))
-    }
-    
-    @available(*, deprecated, renamed: "Point(_:)", message: "Use Point initializer directly")
-    var point: Point {
-        return Point(x: Float(x), y: Float(y))
     }
 }

--- a/Sources/Swift2D/Point.swift
+++ b/Sources/Swift2D/Point.swift
@@ -1,26 +1,26 @@
 /// The representation of a single point in a two-dimensional plane.
 public struct Point {
-    public var x: Float
-    public var y: Float
+    public var x: Double
+    public var y: Double
     
     public init() {
         x = 0.0
         y = 0.0
     }
     
-    public init(x: Float, y: Float) {
+    public init(x: Double, y: Double) {
         self.x = x
         self.y = y
     }
     
-    public init(x: Int, y: Int) {
-        self.x = Float(x)
-        self.y = Float(y)
+    public init(x: Float, y: Float) {
+        self.x = Double(x)
+        self.y = Double(y)
     }
     
-    public init(x: Double, y: Double) {
-        self.x = Float(x)
-        self.y = Float(y)
+    public init(x: Int, y: Int) {
+        self.x = Double(x)
+        self.y = Double(y)
     }
 }
 

--- a/Sources/Swift2D/Rect+Computed.swift
+++ b/Sources/Swift2D/Rect+Computed.swift
@@ -29,22 +29,22 @@ public extension Rect {
 // MARK: - Convenience Accessors
 public extension Rect {
     /// The x-coordinate of the rectangle origin
-    var x: Float {
+    var x: Double {
         return origin.x
     }
     
     /// The y-coordinate of the rectangle origin
-    var y: Float {
+    var y: Double {
         return origin.y
     }
     
     /// The width of the rectangle.
-    var width: Float {
+    var width: Double {
         return size.width
     }
     
     /// The height of the rectangle.
-    var height: Float {
+    var height: Double {
         return size.height
     }
     
@@ -53,7 +53,7 @@ public extension Rect {
     }
     
     /// The smallest value for the x-coordinate of the rectangle.
-    var minX: Float {
+    var minX: Double {
         if size.width < 0.0 {
             return origin.x - abs(size.width)
         }
@@ -62,12 +62,12 @@ public extension Rect {
     }
     
     /// The x-coordinate that establishes the center of a rectangle.
-    var midX: Float {
+    var midX: Double {
         return minX + size.xRadius
     }
     
     /// The largest value of the x-coordinate for the rectangle.
-    var maxX: Float {
+    var maxX: Double {
         if size.width < 0.0 {
            return origin.x
         }
@@ -76,7 +76,7 @@ public extension Rect {
     }
     
     /// The smallest value for the y-coordinate of the rectangle.
-    var minY: Float {
+    var minY: Double {
         if size.height < 0.0 {
             return origin.y - abs(size.height)
         }
@@ -85,12 +85,12 @@ public extension Rect {
     }
     
     /// The y-coordinate that establishes the center of the rectangle.
-    var midY: Float {
+    var midY: Double {
         return minY + size.yRadius
     }
     
     /// The largest value for the y-coordinate of the rectangle.
-    var maxY: Float {
+    var maxY: Double {
         if size.height < 0.0 {
             return origin.y
         }
@@ -152,7 +152,7 @@ public extension Rect {
         }
         
         let overlapH = r1spanH.clamped(to: r2spanH)
-        let width: Float
+        let width: Double
         if overlapH == r1spanH {
             width = r1.width
         } else if overlapH == r2spanH {
@@ -162,7 +162,7 @@ public extension Rect {
         }
         
         let overlapV = r1spanV.clamped(to: r2spanV)
-        let height: Float
+        let height: Double
         if overlapV == r1spanV {
             height = r1.height
         } else if overlapV == r2spanV {
@@ -197,7 +197,7 @@ public extension Rect {
 
 // MARK: - Transformations (offset/inset)
 public extension Rect {
-    func offsetBy(dx: Float, dy: Float) -> Rect {
+    func offsetBy(dx: Double, dy: Double) -> Rect {
         guard !isNull else {
             return self
         }
@@ -208,7 +208,7 @@ public extension Rect {
         return rect
     }
     
-    func insetBy(dx: Float, dy: Float) -> Rect {
+    func insetBy(dx: Double, dy: Double) -> Rect {
         guard !isNull else {
             return self
         }
@@ -226,7 +226,7 @@ public extension Rect {
         return rect
     }
     
-    func expandedBy(dx: Float, dy: Float) -> Rect {
+    func expandedBy(dx: Double, dy: Double) -> Rect {
         return insetBy(dx: -dx, dy: -dy)
     }
 }

--- a/Sources/Swift2D/Rect+CoreGraphics.swift
+++ b/Sources/Swift2D/Rect+CoreGraphics.swift
@@ -31,9 +31,4 @@ public extension CGRect {
             height: CGFloat(rect.height)
         )
     }
-    
-    @available(*, deprecated, renamed: "Rect(_:)", message: "Use Rect initializer directly")
-    var rect: Rect {
-        return Rect(origin: origin.point, size: size.size)
-    }
 }

--- a/Sources/Swift2D/Rect.swift
+++ b/Sources/Swift2D/Rect.swift
@@ -15,17 +15,17 @@ public struct Rect {
         self.size = size
     }
     
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        origin = Point(x: x, y: y)
+        size = Size(width: width, height: height)
+    }
+    
     public init(x: Float, y: Float, width: Float, height: Float) {
         origin = Point(x: x, y: y)
         size = Size(width: width, height: height)
     }
     
     public init(x: Int, y: Int, width: Int, height: Int) {
-        origin = Point(x: x, y: y)
-        size = Size(width: width, height: height)
-    }
-    
-    public init(x: Double, y: Double, width: Double, height: Double) {
         origin = Point(x: x, y: y)
         size = Size(width: width, height: height)
     }

--- a/Sources/Swift2D/Size+Computed.swift
+++ b/Sources/Swift2D/Size+Computed.swift
@@ -1,8 +1,8 @@
 // MARK: - Common References
 public extension Size {
     static let zero: Size = Size(width: 0.0, height: 0.0)
-    static let nan: Size = Size(width: Float.nan, height: Float.nan)
-    internal static let infinite: Size = Size(width: Float.greatestFiniteMagnitude, height: Float.greatestFiniteMagnitude)
+    static let nan: Size = Size(width: Double.nan, height: Double.nan)
+    internal static let infinite: Size = Size(width: Double.greatestFiniteMagnitude, height: Double.greatestFiniteMagnitude)
     
     var isZero: Bool {
         return self == .zero
@@ -16,22 +16,22 @@ public extension Size {
 // MARK: - Convenience Accessors
 public extension Size {
     /// The horizontal radius (½ of `width`)
-    var xRadius: Float {
+    var xRadius: Double {
         return abs(width) / 2.0
     }
     
     /// The vertical radius (½ of `height`)
-    var yRadius: Float {
+    var yRadius: Double {
         return abs(height) / 2.0
     }
     
     /// The largest radius, out of `xRadius` & `yRadius`.
-    var maxRadius: Float {
+    var maxRadius: Double {
         return max(xRadius, yRadius)
     }
     
     /// The smallest radius, out of `xRadius` & `yRadius`.
-    var minRadius: Float {
+    var minRadius: Double {
         return min(xRadius, yRadius)
     }
     

--- a/Sources/Swift2D/Size+CoreGraphics.swift
+++ b/Sources/Swift2D/Size+CoreGraphics.swift
@@ -7,12 +7,7 @@ import Foundation
 public extension Size {
     /// Initialize a `Size` using the provided `CGSize` values.
     init(_ size: CGSize) {
-        self.init(width: Float(size.width), height: Float(size.height))
-    }
-    
-    @available(*, deprecated, renamed: "CGSize(_:)", message: "Use CGSize initializer directly")
-    var cgSize: CGSize {
-        return CGSize(self)
+        self.init(width: Double(size.width), height: Double(size.height))
     }
 }
 
@@ -20,10 +15,5 @@ public extension CGSize {
     /// Initialize a `CGSize` using the provided `Size` values.
     init(_ size: Size) {
         self.init(width: CGFloat(size.width), height: CGFloat(size.height))
-    }
-    
-    @available(*, deprecated, renamed: "Size(_:)", message: "Use Size initializer directly")
-    var size: Size {
-        return Size(width: Float(width), height: Float(height))
     }
 }

--- a/Sources/Swift2D/Size.swift
+++ b/Sources/Swift2D/Size.swift
@@ -1,26 +1,26 @@
 /// A representation of two-dimensional width and height values.
 public struct Size {
-    public var width: Float
-    public var height: Float
+    public var width: Double
+    public var height: Double
     
     public init() {
         width = 0.0
         height = 0.0
     }
     
-    public init(width: Float, height: Float) {
+    public init(width: Double, height: Double) {
         self.width = width
         self.height = height
     }
     
-    public init(width: Int, height: Int) {
-        self.width = Float(width)
-        self.height = Float(height)
+    public init(width: Float, height: Float) {
+        self.width = Double(width)
+        self.height = Double(height)
     }
     
-    public init(width: Double, height: Double) {
-        self.width = Float(width)
-        self.height = Float(height)
+    public init(width: Int, height: Int) {
+        self.width = Double(width)
+        self.height = Double(height)
     }
 }
 

--- a/Tests/Swift2DTests/PointTests.swift
+++ b/Tests/Swift2DTests/PointTests.swift
@@ -34,8 +34,8 @@ final class PointTests: XCTestCase {
         XCTAssertEqual(point.y, 8.123)
         
         point = .init(x: 0.123456789, y: 0.987654321)
-        XCTAssertEqual(point.x, 0.12345679)
-        XCTAssertEqual(point.y, 0.9876543)
+        XCTAssertEqual(point.x, 0.123456789)
+        XCTAssertEqual(point.y, 0.987654321)
     }
     
     func testCustomStringConvertible() throws {
@@ -83,7 +83,7 @@ final class PointTests: XCTestCase {
         
         let encoded = try JSONEncoder().encode(point)
         #if canImport(ObjectiveC)
-        let dictionary = try XCTUnwrap(try JSONSerialization.jsonObject(with: encoded, options: .init()) as? [String: Float])
+        let dictionary = try XCTUnwrap(try JSONSerialization.jsonObject(with: encoded, options: .init()) as? [String: Double])
         XCTAssertEqual(dictionary["x"], 0.111234)
         XCTAssertEqual(dictionary["y"], 45.763)
         #else

--- a/Tests/Swift2DTests/RectTests.swift
+++ b/Tests/Swift2DTests/RectTests.swift
@@ -53,10 +53,10 @@ final class RectTests: XCTestCase {
         XCTAssertEqual(rect.size.height, 4.0)
         
         rect = .init(origin: Point(x: 4.87654321, y: 5.87654321), size: Size(width: 6.87654321, height: 7.87654321))
-        XCTAssertEqual(rect.origin.x, 4.8765432)
-        XCTAssertEqual(rect.origin.y, 5.8765432)
-        XCTAssertEqual(rect.size.width, 6.8765432)
-        XCTAssertEqual(rect.size.height, 7.8765432)
+        XCTAssertEqual(rect.origin.x, 4.87654321)
+        XCTAssertEqual(rect.origin.y, 5.87654321)
+        XCTAssertEqual(rect.size.width, 6.87654321)
+        XCTAssertEqual(rect.size.height, 7.87654321)
     }
     
     func testCustomStringConvertible() throws {
@@ -123,7 +123,7 @@ final class RectTests: XCTestCase {
         
         let encoded = try JSONEncoder().encode(rect)
         #if canImport(ObjectiveC)
-        let dictionary = try XCTUnwrap(try JSONSerialization.jsonObject(with: encoded, options: .init()) as? [String: [String: Float]])
+        let dictionary = try XCTUnwrap(try JSONSerialization.jsonObject(with: encoded, options: .init()) as? [String: [String: Double]])
         XCTAssertEqual(dictionary["origin"]?["x"], 9.8)
         XCTAssertEqual(dictionary["origin"]?["y"], 8.7)
         XCTAssertEqual(dictionary["size"]?["width"], 7.6)
@@ -162,10 +162,10 @@ final class RectTests: XCTestCase {
         XCTAssertFalse(rect.isEmpty)
         
         rect = .infinite
-        XCTAssertEqual(rect.origin.x, -Float.greatestFiniteMagnitude / 2)
-        XCTAssertEqual(rect.origin.y, -Float.greatestFiniteMagnitude / 2)
-        XCTAssertEqual(rect.size.width, Float.greatestFiniteMagnitude)
-        XCTAssertEqual(rect.size.height, Float.greatestFiniteMagnitude)
+        XCTAssertEqual(rect.origin.x, -Double.greatestFiniteMagnitude / 2)
+        XCTAssertEqual(rect.origin.y, -Double.greatestFiniteMagnitude / 2)
+        XCTAssertEqual(rect.size.width, Double.greatestFiniteMagnitude)
+        XCTAssertEqual(rect.size.height, Double.greatestFiniteMagnitude)
         XCTAssertFalse(rect.isZero)
         XCTAssertFalse(rect.isNaN)
         XCTAssertTrue(rect.isInfinite)
@@ -173,8 +173,8 @@ final class RectTests: XCTestCase {
         XCTAssertTrue(rect.isEmpty)
         
         rect = .null
-        XCTAssertEqual(rect.origin.x, Float.infinity)
-        XCTAssertEqual(rect.origin.y, Float.infinity)
+        XCTAssertEqual(rect.origin.x, Double.infinity)
+        XCTAssertEqual(rect.origin.y, Double.infinity)
         XCTAssertEqual(rect.size.width, 0.0)
         XCTAssertEqual(rect.size.height, 0.0)
         XCTAssertFalse(rect.isZero)

--- a/Tests/Swift2DTests/SizeTests.swift
+++ b/Tests/Swift2DTests/SizeTests.swift
@@ -34,8 +34,8 @@ final class SizeTests: XCTestCase {
         XCTAssertEqual(size.height, 8.123)
         
         size = .init(width: 0.123456789, height: 0.987654321)
-        XCTAssertEqual(size.width, 0.12345679)
-        XCTAssertEqual(size.height, 0.9876543)
+        XCTAssertEqual(size.width, 0.123456789)
+        XCTAssertEqual(size.height, 0.987654321)
     }
     
     func testCustomStringConvertible() throws {
@@ -79,7 +79,7 @@ final class SizeTests: XCTestCase {
         
         let encoded = try JSONEncoder().encode(size)
         #if canImport(ObjectiveC)
-        let dictionary = try XCTUnwrap(try JSONSerialization.jsonObject(with: encoded, options: .init()) as? [String: Float])
+        let dictionary = try XCTUnwrap(try JSONSerialization.jsonObject(with: encoded, options: .init()) as? [String: Double])
         XCTAssertEqual(dictionary["width"], 0.111234)
         XCTAssertEqual(dictionary["height"], 45.763)
         #else


### PR DESCRIPTION
Replaces the storage type Float with Double.
The upcoming [SE-0307](https://github.com/apple/swift-evolution/blob/main/proposals/0307-allow-interchangeable-use-of-double-cgfloat-types.md) implemented in Swift 5.5 will allow for interoperability between CGFloat and Double. Since `Double` is the native floating point type in Swift, the underlying storage value type have all been updated to Double.